### PR TITLE
Update npm mirror config

### DIFF
--- a/Shell/QLOneKeyDependency.sh
+++ b/Shell/QLOneKeyDependency.sh
@@ -44,7 +44,7 @@ echo
 "当前npm版本(如果没有npm，请自行安装): "
 npm -v
 
-npm config set registry https://registry.npm.taobao.org
+npm config set registry https://registry.npmmirror.com
 cd /ql
 pnpm add -g pnpm
 

--- a/Shell/XinQLOneKey.sh
+++ b/Shell/XinQLOneKey.sh
@@ -44,7 +44,7 @@ echo
 "当前npm版本(如果没有npm，请自行安装): "
 npm -v
 
-npm config set registry https://registry.npm.taobao.org
+npm config set registry https://registry.npmmirror.com
 cd /ql
 pnpm add -g pnpm
 


### PR DESCRIPTION
更新npm镜像源为`registry.npmmirror.com`

具体原因参见如下公告：
[【公告】淘宝 npm 域名即将切换 && npmmirror 重构升级](https://zhuanlan.zhihu.com/p/465424728?spm=a2c6h.24755359.0.0.6d444dccWkmhDX)