### PR TITLE
doc: 修改一处笔误

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ docker exec -it qinglong bash -c "$(curl -fsSL https://ghproxy.com/https://raw.g
 
 ```bash
 
-Docker restart qinglong
+docker restart qinglong
 
 ```
 


### PR DESCRIPTION
Docker 的默认命令应该是小写 docker , 修改以防止复制命令时出现错误。