### PR TITLE
fix: upgrade deprecated GitHub Actions (checkout@v1/v2→v4, codeql@v1→v3, set-output→GITHUB_OUTPUT)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
## Summary
Upgrades deprecated GitHub Actions to current versions:

### release.yml
- `actions/checkout@v1` → `actions/checkout@v4` (Node 20 runtime required)
- `::set-output name=VERSION::...` → `echo "VERSION=..." >> \` (deprecated syntax fix, prevents GitHub Actions deprecation warnings)

### codeql.yml
- `actions/checkout@v2` → `actions/checkout@v4`
- `github/codeql-action/*@v1` → `github/codeql-action/*@v3`

These updates eliminate deprecation warnings in CI runs and ensure compatibility with current GitHub Actions infrastructure.

---
*Submitted via PR攻关 workflow.*